### PR TITLE
fix(windows): use path.posix.sep instead of path.sep to split glob paths

### DIFF
--- a/src/documents/deps.ts
+++ b/src/documents/deps.ts
@@ -25,7 +25,7 @@ function nameFormatter(descriptor: LoadedModuleDescriptor, folderName: string, d
 }
 
 function getLoadDocumentDep(folderName: string, fileMask: string, groupName?: string, pluginGroupName?: string): LoadDepsFromFolderOptions {
-    const [docType, depDir] = folderName.split(path.sep).slice(-2)
+    const [docType, depDir] = folderName.split(/[\\/]/).slice(-2)
     const depType = singular(depDir)
 
     return {


### PR DESCRIPTION
Split here is virtual name, so it's written as `aaa/someDep`, so I just being extra careful and use both slashes.